### PR TITLE
Goのバージョンを1.23.1に更新

### DIFF
--- a/ast/go.mod
+++ b/ast/go.mod
@@ -1,3 +1,3 @@
 module okuzawats.com/go/ast
 
-go 1.19
+go 1.23.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module okuzawats.com/go
 
-go 1.19
+go 1.23.1
 
 require local.packages/ast v0.0.0
 

--- a/lexer/go.mod
+++ b/lexer/go.mod
@@ -1,3 +1,3 @@
 module okuzawats.com/go/lexer
 
-go 1.19
+go 1.23.1

--- a/parser/go.mod
+++ b/parser/go.mod
@@ -1,11 +1,15 @@
 module okuzawats.com/go/parser
 
-go 1.19
+go 1.23.1
 
 require local.packages/ast v0.0.0
+
 require local.packages/lexer v0.0.0
+
 require local.packages/token v0.0.0
 
 replace local.packages/ast => ../ast
+
 replace local.packages/lexer => ../lexer
+
 replace local.packages/token => ../token

--- a/repl/go.mod
+++ b/repl/go.mod
@@ -1,3 +1,3 @@
 module okuzawats.com/go/repl
 
-go 1.19
+go 1.23.1

--- a/token/go.mod
+++ b/token/go.mod
@@ -1,3 +1,3 @@
 module okuzawats.com/go/token
 
-go 1.19
+go 1.23.1


### PR DESCRIPTION
各パッケージで以下のコマンドを実行してGo言語のバージョンを `1.23.1` に更新した。

```
% go mod edit -go=1.23.1
```
